### PR TITLE
Update GitHub Actions workflow to conditionally run dependency review…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ env:
 jobs:
   dependency-review:
     name: Dependency Review
+    # Only run this job for pull requests
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/main.yml` file. The change ensures that the `Dependency Review` job only runs for pull requests.

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R23-R24): Added a condition to run the `Dependency Review` job only for pull requests.